### PR TITLE
Added help tool avro_builder to construct avro schemas

### DIFF
--- a/lang/py/src/avro/avro_builder.py
+++ b/lang/py/src/avro/avro_builder.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+import copy
+
+from avro import schema
+
+
+class AvroBuildInvalidOperation(Exception):
+    pass
+
+
+class AvroSchemaBuilder(object):
+    """
+    AvroSchemaBuilder creates json-formatted Avro schemas. It has `create_*`
+    function for each primitive type to create primitive types. To create a
+    complex type, start with corresponding `begin_*` function and finish it
+    with `end` function.
+
+    It defers the schema validation until the end of schema building. When
+    the schema building ends, it constructs the corresponding schema object
+    which will validate the the syntax of the Avro json object.
+
+    For each schema type, it also has *_type property that returns a type
+    string and can be used to set `type` attribute of a schema. For example,
+    `null_type` is string `null` and `record_type` is string `record`.
+
+    Usage: (unit tests cover more usages)
+      ab = AvroSchemaBuilder()
+
+      - building a record schema:
+        ab.begin_record('user', namespace='yelp')
+        ab.begin_field('id', ab.create_int()).end_field()
+        ab.begin_field(
+            'fav_color',
+            ab.begin_enum('color_enum', ['red', 'blue']
+        ).end_field()
+        record = ab.end()
+
+      - building an enum schema:
+        enum_schema = ab.begin_enum('color_enum', ['red', 'blue']).end()
+
+      - building an array schema:
+        array_schema = ab.begin_array(ab.create_string()).end()
+    """
+
+    def __init__(self):
+        self._schema_json = None  # current avro schema in build
+        self._schema_tracker = []
+
+    def create_null(self):
+        return 'null'
+
+    def create_boolean(self):
+        return 'boolean'
+
+    def create_int(self):
+        return 'int'
+
+    def create_long(self):
+        return 'long'
+
+    def create_float(self):
+        return 'float'
+
+    def create_double(self):
+        return 'double'
+
+    def create_bytes(self):
+        return 'bytes'
+
+    def create_string(self):
+        return 'string'
+
+    def begin_enum(self, name, symbols, namespace=None, aliases=None,
+                   doc=None, **metadata):
+        enum_schema = {
+            'type': 'enum',
+            'name': name,
+            'symbols': symbols
+        }
+        if namespace:
+            self._set_namespace(enum_schema, namespace)
+        if aliases:
+            self._set_aliases(enum_schema, aliases)
+        if doc:
+            self._set_doc(enum_schema, doc)
+        enum_schema.update(metadata)
+
+        self._save_current_schema()
+        self._set_current_schema(enum_schema)
+        return self
+
+    def begin_fixed(self, name, size, namespace=None, aliases=None,
+                    **metadata):
+        fixed_schema = {
+            'type': 'fixed',
+            'name': name,
+            'size': size
+        }
+        if namespace:
+            self._set_namespace(fixed_schema, namespace)
+        if aliases:
+            self._set_aliases(fixed_schema, aliases)
+        fixed_schema.update(metadata)
+
+        self._save_current_schema()
+        self._set_current_schema(fixed_schema)
+        return self
+
+    def begin_array(self, items_schema, **metadata):
+        array_schema = {'type': 'array', 'items': items_schema}
+        array_schema.update(metadata)
+        self._save_current_schema()
+        self._set_current_schema(array_schema)
+        return self
+
+    def begin_map(self, values_schema, **metadata):
+        map_schema = {'type': 'map', 'values': values_schema}
+        map_schema.update(metadata)
+        self._save_current_schema()
+        self._set_current_schema(map_schema)
+        return self
+
+    def begin_record(self, name, namespace=None, aliases=None, doc=None,
+                     **metadata):
+        record_schema = {'type': 'record', 'name': name, 'fields': []}
+        if namespace is not None:
+            self._set_namespace(record_schema, namespace)
+        if aliases:
+            self._set_aliases(record_schema, aliases)
+        if doc:
+            self._set_doc(record_schema, doc)
+        record_schema.update(metadata)
+
+        self._save_current_schema()
+        self._set_current_schema(record_schema)
+        return self
+
+    def begin_field(self, name, typ, has_default=False, default_value=None,
+                    sort_order=None, aliases=None, doc=None, **metadata):
+        field = {'name': name, 'type': typ}
+        if has_default:
+            field['default'] = default_value
+        if sort_order:
+            field['order'] = sort_order
+        if aliases:
+            self._set_aliases(field, aliases)
+        if doc:
+            self._set_doc(field, doc)
+        field.update(metadata)
+
+        self._save_current_schema()
+        self._set_current_schema(field)
+        return self
+
+    def end_field(self):
+        field = self._schema_json
+        self._restore_current_schema()
+        self._schema_json['fields'].append(field)
+
+    def begin_union(self, *avro_schemas):
+        union_schema = list(avro_schemas)
+        self._save_current_schema()
+        self._set_current_schema(union_schema)
+        return self
+
+    def end(self):
+        if not self._schema_tracker:
+            # this is the top level schema; do the schema validation
+            schema_obj = schema.make_avsc_object(self._schema_json)
+            self._schema_json = None
+            return schema_obj.to_json()
+
+        current_schema_json = self._schema_json
+        self._restore_current_schema()
+        return current_schema_json
+
+    def _save_current_schema(self):
+        if self._schema_json:
+            self._schema_tracker.append(self._schema_json)
+
+    def _set_current_schema(self, avro_schema):
+        self._schema_json = avro_schema
+
+    def _restore_current_schema(self):
+        self._schema_json = self._schema_tracker.pop()
+
+    @classmethod
+    def _set_namespace(cls, avro_schema, namespace):
+        avro_schema['namespace'] = namespace
+
+    @classmethod
+    def _set_aliases(cls, avro_schema, aliases):
+        avro_schema['aliases'] = aliases
+
+    @classmethod
+    def _set_doc(cls, avro_schema, doc):
+        avro_schema['doc'] = doc
+
+    def begin_nullable_type(self, schema_type, default_value=None):
+        """Create an Avro schema that represents the nullable `schema_type`.
+        The nullable type is a union schema type with `null` primitive type.
+        The given default value is used to determine whether the `null` type
+        should be the first item in the union type.
+        """
+        null_type = self.create_null()
+
+        src_type = copy.deepcopy(schema_type)
+        if self._is_nullable_type(schema_type):
+            nullable_schema = src_type
+        else:
+            typ = src_type if isinstance(src_type, list) else [src_type]
+            if default_value is None:
+                typ.insert(0, null_type)
+            else:
+                typ.append(null_type)
+            nullable_schema = self.begin_union(*typ).end()
+
+        self._save_current_schema()
+        self._set_current_schema(nullable_schema)
+        return self
+
+    def _is_nullable_type(self, schema_type):
+        null_type = self.create_null()
+        return (schema_type is not None
+                and (schema_type == null_type
+                     or any(typ == null_type for typ in schema_type)))
+
+    def begin_with_schema_json(self, schema_json):
+        """Begin building the given schema json object. Note that, similar to
+        other `begin_*` functions, it doesn't validate the input schema json
+        object until the end of schema.
+        """
+        self._save_current_schema()
+        self._set_current_schema(copy.deepcopy(schema_json))
+        return self
+
+    def remove_field(self, field_name):
+        fields = self._schema_json.get('fields', [])
+        field = next((f for f in fields if f['name'] == field_name), None)
+        if not field:
+            raise AvroBuildInvalidOperation(
+                'Cannot find field named {0}'.format(field_name)
+            )
+        fields.remove(field)
+
+    def clear(self):
+        """Clear the schemas that are built so far."""
+        self._schema_json = None
+        self._schema_tracker = []

--- a/lang/py/src/avro/avro_builder.py
+++ b/lang/py/src/avro/avro_builder.py
@@ -19,10 +19,6 @@ class AvroSchemaBuilder(object):
     the schema building ends, it constructs the corresponding schema object
     which will validate the the syntax of the Avro json object.
 
-    For each schema type, it also has *_type property that returns a type
-    string and can be used to set `type` attribute of a schema. For example,
-    `null_type` is string `null` and `record_type` is string `record`.
-
     Usage: (unit tests cover more usages)
       ab = AvroSchemaBuilder()
 

--- a/lang/py/src/avro/avro_builder.py
+++ b/lang/py/src/avro/avro_builder.py
@@ -28,11 +28,11 @@ class AvroSchemaBuilder(object):
 
       - building a record schema:
         ab.begin_record('user', namespace='yelp')
-        ab.begin_field('id', ab.create_int()).end_field()
-        ab.begin_field(
+        ab.add_field('id', ab.create_int())
+        ab.add_field(
             'fav_color',
-            ab.begin_enum('color_enum', ['red', 'blue']
-        ).end_field()
+            ab.begin_enum('color_enum', ['red', 'blue']).end()
+        )
         record = ab.end()
 
       - building an enum schema:
@@ -135,8 +135,8 @@ class AvroSchemaBuilder(object):
         self._set_current_schema(record_schema)
         return self
 
-    def begin_field(self, name, typ, has_default=False, default_value=None,
-                    sort_order=None, aliases=None, doc=None, **metadata):
+    def add_field(self, name, typ, has_default=False, default_value=None,
+                  sort_order=None, aliases=None, doc=None, **metadata):
         field = {'name': name, 'type': typ}
         if has_default:
             field['default'] = default_value
@@ -148,13 +148,6 @@ class AvroSchemaBuilder(object):
             self._set_doc(field, doc)
         field.update(metadata)
 
-        self._save_current_schema()
-        self._set_current_schema(field)
-        return self
-
-    def end_field(self):
-        field = self._schema_json
-        self._restore_current_schema()
         self._schema_json['fields'].append(field)
 
     def begin_union(self, *avro_schemas):

--- a/lang/py/test/test_avro_builder.py
+++ b/lang/py/test/test_avro_builder.py
@@ -1,0 +1,584 @@
+# -*- coding: utf-8 -*-
+import unittest2 as unittest
+
+from avro import avro_builder
+from avro import schema
+
+
+class TestAvroSchemaBuilder(unittest.TestCase):
+
+    def setUp(self):
+        self.builder = avro_builder.AvroSchemaBuilder()
+
+    def tearDown(self):
+        del self.builder
+
+    @property
+    def name(self):
+        return 'foo'
+
+    @property
+    def namespace(self):
+        return 'ns'
+
+    @property
+    def aliases(self):
+        return ['new_foo']
+
+    @property
+    def doc(self):
+        return 'sample doc'
+
+    @property
+    def metadata(self):
+        return {'key1': 'val1', 'key2': 'val2'}
+
+    @property
+    def enum_symbols(self):
+        return ['a', 'b']
+
+    @property
+    def fixed_size(self):
+        return 16
+    
+    @property
+    def another_name(self):
+        return 'bar'
+
+    @property
+    def invalid_schemas(self):
+        undefined_schema_name = 'unknown'
+        yield undefined_schema_name
+
+        non_avro_schema = {'foo': 'bar'}
+        yield non_avro_schema
+
+        named_schema_without_name = {'name': '', 'type': 'fixed', 'size': 16}
+        yield named_schema_without_name
+
+        invalid_schema = {'name': 'foo', 'type': 'enum', 'symbols': ['a', 'a']}
+        yield invalid_schema
+
+        none_schema = None
+        yield none_schema
+
+    @property
+    def invalid_names(self):
+        missing_name = None
+        yield missing_name
+
+        reserved_name = 'int'
+        yield reserved_name
+
+        non_string_name = 100
+        yield non_string_name
+
+    @property
+    def duplicate_name_err(self):
+        return '"{0}" is already in use.'
+
+    def test_create_primitive_types(self):
+        self.assertEqual('null', self.builder.create_null())
+        self.assertEqual('boolean', self.builder.create_boolean())
+        self.assertEqual('int', self.builder.create_int())
+        self.assertEqual('long', self.builder.create_long())
+        self.assertEqual('float', self.builder.create_float())
+        self.assertEqual('double', self.builder.create_double())
+        self.assertEqual('bytes', self.builder.create_bytes())
+        self.assertEqual('string', self.builder.create_string())
+
+    def test_create_enum(self):
+        actual_json = self.builder.begin_enum(self.name, self.enum_symbols).end()
+        expected_json = {
+            'type': 'enum',
+            'name': self.name,
+            'symbols': self.enum_symbols
+        }
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_enum_with_optional_attributes(self):
+        actual_json = self.builder.begin_enum(
+            self.name,
+            self.enum_symbols,
+            self.namespace,
+            self.aliases,
+            self.doc,
+            **self.metadata
+        ).end()
+
+        expected_json = {
+            'type': 'enum',
+            'name': self.name,
+            'symbols': self.enum_symbols,
+            'namespace': self.namespace,
+            'aliases': self.aliases,
+            'doc': self.doc
+        }
+        expected_json.update(self.metadata)
+
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_enum_with_invalid_name(self):
+        for invalid_name in self.invalid_names:
+            self.builder.clear()
+            with self.assertRaises(schema.SchemaParseException):
+                self.builder.begin_enum(invalid_name, self.enum_symbols).end()
+
+
+    def test_create_enum_with_dup_name(self):
+        with self.assertRaisesRegexp(
+                schema.SchemaParseException,
+                self.duplicate_name_err.format(self.name)
+        ):
+            self.builder.begin_record(self.name)
+            self.builder.begin_field(
+                self.another_name,
+                self.builder.begin_enum(self.name, self.enum_symbols).end()
+            ).end_field()
+            self.builder.end()
+
+    def test_create_enum_with_invalid_symbols(self):
+        self.single_test_create_enum_with_invalid_symbols(None)
+        self.single_test_create_enum_with_invalid_symbols('')
+        self.single_test_create_enum_with_invalid_symbols('a')
+        self.single_test_create_enum_with_invalid_symbols(['a', 1])
+        self.single_test_create_enum_with_invalid_symbols([1, 2, 3])
+        self.single_test_create_enum_with_invalid_symbols(['a', 'a'])
+
+    def single_test_create_enum_with_invalid_symbols(self, invalid_symbols):
+        self.builder.clear()
+        with self.assertRaises(schema.AvroException):
+            self.builder.begin_enum(self.name, invalid_symbols).end()
+
+    def test_create_fixed(self):
+        actual_json = self.builder.begin_fixed(self.name, self.fixed_size).end()
+        expected_json = {
+            'type': 'fixed',
+            'name': self.name,
+            'size': self.fixed_size
+        }
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_fixed_with_optional_attributes(self):
+        actual_json = self.builder.begin_fixed(
+            self.name,
+            self.fixed_size,
+            self.namespace,
+            self.aliases,
+            **self.metadata
+        ).end()
+
+        expected_json = {
+            'type': 'fixed',
+            'name': self.name,
+            'size': self.fixed_size,
+            'namespace': self.namespace,
+            'aliases': self.aliases,
+        }
+        expected_json.update(self.metadata)
+
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_fixed_with_invalid_name(self):
+        for invalid_name in self.invalid_names:
+            self.builder.clear()
+            with self.assertRaises(schema.SchemaParseException):
+                self.builder.begin_fixed(invalid_name, self.fixed_size).end()
+
+    def test_create_fixed_with_dup_name(self):
+        with self.assertRaisesRegexp(
+                schema.SchemaParseException,
+                self.duplicate_name_err.format(self.name)
+        ):
+            self.builder.begin_record(self.name)
+            self.builder.begin_field(
+                self.another_name,
+                self.builder.begin_fixed(self.name, self.fixed_size).end()
+            ).end_field()
+            self.builder.end()
+
+    def test_create_fixed_with_invalid_size(self):
+        self.single_test_create_fixed_with_invalid_size(None)
+        self.single_test_create_fixed_with_invalid_size('ten')
+
+    def single_test_create_fixed_with_invalid_size(self, invalid_size):
+        self.builder.clear()
+        with self.assertRaises(schema.AvroException):
+            self.builder.begin_fixed(self.name, invalid_size).end()
+
+    def test_create_array(self):
+        actual_json = self.builder.begin_array(self.builder.create_int()).end()
+        expected_json = {'type': 'array', 'items': 'int'}
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_array_with_optional_attributes(self):
+        actual_json = self.builder.begin_array(
+            self.builder.create_int(),
+            **self.metadata
+        ).end()
+
+        expected_json = {'type': 'array', 'items': 'int'}
+        expected_json.update(self.metadata)
+
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_array_with_complex_type(self):
+        actual_json = self.builder.begin_array(
+            self.builder.begin_enum(self.name, self.enum_symbols).end()
+        ).end()
+        expected_json = {
+            'type': 'array',
+            'items': {
+                'type': 'enum',
+                'name': self.name,
+                'symbols': self.enum_symbols
+            }
+        }
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_array_with_invalid_items_type(self):
+        for invalid_schema in self.invalid_schemas:
+            self.builder.clear()
+            with self.assertRaises(schema.AvroException):
+                self.builder.begin_array(invalid_schema).end()
+
+    def test_create_map(self):
+        actual_json = self.builder.begin_map(self.builder.create_string()).end()
+        expected_json = {'type': 'map', 'values': 'string'}
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_map_with_optional_attributes(self):
+        actual_json = self.builder.begin_map(
+            self.builder.create_string(),
+            **self.metadata
+        ).end()
+
+        expected_json = {'type': 'map', 'values': 'string'}
+        expected_json.update(self.metadata)
+
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_map_with_complex_type(self):
+        actual_json = self.builder.begin_map(
+            self.builder.begin_fixed(self.name, self.fixed_size).end()
+        ).end()
+        expected_json = {
+            'type': 'map',
+            'values': {
+                'type': 'fixed',
+                'name': self.name,
+                'size': self.fixed_size
+            }
+        }
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_map_with_invalid_values_type(self):
+        for invalid_schema in self.invalid_schemas:
+            self.builder.clear()
+            with self.assertRaises(schema.AvroException):
+                self.builder.begin_map(invalid_schema).end()
+
+    def test_create_record(self):
+        self.builder.begin_record(self.name)
+        self.builder.begin_field(
+            'bar1',
+            self.builder.create_int()
+        ).end_field()
+        self.builder.begin_field(
+            'bar2',
+            self.builder.begin_map(self.builder.create_double()).end()
+        ).end_field()
+        actual_json = self.builder.end()
+
+        expected_json = {
+            'type': 'record',
+            'name': self.name,
+            'fields': [
+                {'name': 'bar1', 'type': 'int'},
+                {'name': 'bar2', 'type': {'type': 'map', 'values': 'double'}}
+            ]
+        }
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_record_with_optional_attributes(self):
+        self.builder.begin_record(
+            self.name,
+            namespace=self.namespace,
+            aliases=self.aliases,
+            doc=self.doc,
+            **self.metadata
+        )
+        self.builder.begin_field(
+            self.another_name,
+            self.builder.create_int()
+        ).end_field()
+        actual_json = self.builder.end()
+
+        expected_json = {
+            'type': 'record',
+            'name': self.name,
+            'fields': [{'name': self.another_name, 'type': 'int'}],
+            'namespace': self.namespace,
+            'aliases': self.aliases,
+            'doc': self.doc
+        }
+        expected_json.update(self.metadata)
+
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_field_with_optional_attributes(self):
+        self.builder.begin_record(self.name)
+        self.builder.begin_field(
+            self.another_name,
+            self.builder.create_boolean(),
+            has_default=True,
+            default_value=True,
+            sort_order='ascending',
+            aliases=self.aliases,
+            doc=self.doc,
+            **self.metadata
+        ).end_field()
+        actual_json = self.builder.end()
+
+        expected_field = {
+            'name': self.another_name,
+            'type': 'boolean',
+            'default': True,
+            'order': 'ascending',
+            'aliases': self.aliases,
+            'doc': self.doc
+        }
+        expected_field.update(self.metadata)
+        expected_json = {
+            'type': 'record',
+            'name': self.name,
+            'fields': [expected_field]
+        }
+
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_record_with_no_field(self):
+        actual_json = self.builder.begin_record(self.name).end()
+        expected_json = {'type': 'record', 'name': self.name, 'fields': []}
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_record_with_invalid_name(self):
+        for invalid_name in self.invalid_names:
+            self.builder.clear()
+            with self.assertRaises(schema.SchemaParseException):
+                self.builder.begin_record(invalid_name)
+                self.builder.begin_field(
+                    self.another_name,
+                    self.builder.create_int()
+                ).end_field()
+                self.builder.end()
+
+    def test_create_record_with_dup_name(self):
+        with self.assertRaisesRegexp(
+                schema.SchemaParseException,
+                self.duplicate_name_err.format(self.name)
+        ):
+            self.builder.begin_record(self.another_name)
+            self.builder.begin_field(
+                'bar1',
+                self.builder.begin_enum(self.name, self.enum_symbols).end()
+            ).end_field()
+            self.builder.begin_field(
+                'bar2',
+                self.builder.begin_record(self.name).end()
+            ).end_field()
+            self.builder.end()
+
+    def test_create_record_with_dup_field_name(self):
+        with self.assertRaisesRegexp(
+                schema.SchemaParseException,
+                "{0} already in use.".format(self.another_name)
+        ):
+            self.builder.begin_record(self.name)
+            self.builder.begin_field(
+                self.another_name,
+                self.builder.create_int()
+            ).end_field()
+            self.builder.begin_field(
+                self.another_name,
+                self.builder.create_string()
+            ).end_field()
+            self.builder.end()
+
+    def test_create_field_with_invalid_type(self):
+        for invalid_schema in self.invalid_schemas:
+            self.builder.clear()
+            with self.assertRaises(schema.SchemaParseException):
+                self.builder.begin_record(self.name)
+                self.builder.begin_field(
+                    self.another_name,
+                    invalid_schema
+                ).end_field()
+                self.builder.end()
+
+    def test_create_field_with_invalid_sort_order(self):
+        with self.assertRaises(schema.SchemaParseException):
+            self.builder.begin_record(self.name)
+            self.builder.begin_field(
+                self.another_name,
+                self.builder.create_int(),
+                sort_order='asc'
+            ).end_field()
+            self.builder.end()
+
+    def test_create_union(self):
+        actual_json = self.builder.begin_union(
+            self.builder.create_null(),
+            self.builder.create_string(),
+            self.builder.begin_enum(self.name, self.enum_symbols).end()
+        ).end()
+
+        expected_json = [
+            'null',
+            'string',
+            {'type': 'enum', 'name': self.name, 'symbols': self.enum_symbols}
+        ]
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_union_with_empty_sub_schemas(self):
+        actual_json = self.builder.begin_union().end()
+        expected_json = []
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_union_with_nested_union_schema(self):
+        with self.assertRaises(schema.SchemaParseException):
+            self.builder.begin_union(
+                self.builder.begin_union(self.builder.create_int()).end()
+            ).end()
+
+    def test_create_union_with_invalid_schema(self):
+        for invalid_schema in self.invalid_schemas:
+            self.builder.clear()
+            with self.assertRaises(schema.SchemaParseException):
+                self.builder.begin_union(invalid_schema).end()
+
+    def test_create_union_with_dup_primitive_schemas(self):
+        with self.assertRaises(schema.SchemaParseException):
+            self.builder.begin_union(
+                self.builder.create_int(),
+                self.builder.create_int()
+            ).end()
+
+    def test_create_union_with_dup_named_schemas(self):
+        with self.assertRaises(schema.SchemaParseException):
+            self.builder.begin_union(
+                self.builder.begin_enum(self.name, self.enum_symbols).end(),
+                self.builder.begin_fixed(self.name, self.fixed_size).end()
+            ).end()
+
+    def test_create_union_with_dup_complex_schemas(self):
+        with self.assertRaises(schema.SchemaParseException):
+            self.builder.begin_union(
+                self.builder.begin_map(self.builder.create_int()).end(),
+                self.builder.begin_map(self.builder.create_int()).end()
+            ).end()
+
+    def test_create_nullable_type(self):
+        # non-union schema type
+        actual_json = self.builder.begin_nullable_type(
+            self.builder.create_int()
+        ).end()
+        expected_json = ['null', 'int']
+        self.assertEqual(expected_json, actual_json)
+
+        # union schema type
+        actual_json = self.builder.begin_nullable_type(
+            [self.builder.create_int()]
+        ).end()
+        expected_json = ['null', 'int']
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_nullable_type_with_default_value(self):
+        # non-union schema type
+        actual_json = self.builder.begin_nullable_type(
+            self.builder.create_int(),
+            10
+        ).end()
+        expected_json = ['int', 'null']
+        self.assertEqual(expected_json, actual_json)
+
+        # union schema type
+        actual_json = self.builder.begin_nullable_type(
+            [self.builder.create_int()],
+            10
+        ).end()
+        expected_json = ['int', 'null']
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_nullable_type_with_null_type(self):
+        actual_json = self.builder.begin_nullable_type(
+            self.builder.create_null()
+        ).end()
+        expected_json = 'null'
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_nullable_type_with_nullable_type(self):
+        actual_json = self.builder.begin_nullable_type(
+            self.builder.begin_union(
+                self.builder.create_null(),
+                self.builder.create_long()
+            ).end(),
+            10
+        ).end()
+        expected_json = ['null', 'long']
+        self.assertEqual(expected_json, actual_json)
+
+    def test_create_nullable_type_with_invalid_type(self):
+        for invalid_schema in self.invalid_schemas:
+            self.builder.clear()
+            with self.assertRaises(schema.SchemaParseException):
+                self.builder.begin_nullable_type(invalid_schema)
+
+    def test_create_schema_with_preloaded_json(self):
+        schema_json = {
+            'type': 'record',
+            'name': self.name,
+            'fields': [
+                {'name': 'field', 'type': {'type': 'map', 'values': 'double'}}
+            ]
+        }
+        self.builder.begin_with_schema_json(schema_json)
+        self.builder.begin_field(
+            'field_new',
+            self.builder.create_int()
+        ).end_field()
+        actual_json = self.builder.end()
+
+        expected_json = schema_json.copy()
+        expected_json['fields'].append({'name': 'field_new', 'type': 'int'})
+
+        self.assertEqual(expected_json, actual_json)
+
+    def test_removed_field(self):
+        self.builder.begin_record(self.name)
+        self.builder.begin_field('bar1', self.builder.create_int()).end_field()
+        self.builder.begin_field('bar2', self.builder.create_int()).end_field()
+        self.builder.remove_field('bar1')
+        actual_json = self.builder.end()
+
+        expected_json = {
+            'type': 'record',
+            'name': self.name,
+            'fields': [{'name': 'bar2', 'type': 'int'}]
+        }
+        self.assertEqual(expected_json, actual_json)
+
+    def test_removed_nonexistent_field(self):
+        schema_json = {
+            'type': 'record',
+            'name': self.name,
+            'fields': [{'name': 'bar2', 'type': 'int'}]
+        }
+        with self.assertRaises(avro_builder.AvroBuildInvalidOperation):
+            self.builder.begin_with_schema_json(schema_json)
+            self.builder.remove_field('bar1')
+            self.builder.end()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lang/py/test/test_avro_builder.py
+++ b/lang/py/test/test_avro_builder.py
@@ -124,17 +124,16 @@ class TestAvroSchemaBuilder(unittest.TestCase):
             with self.assertRaises(schema.SchemaParseException):
                 self.builder.begin_enum(invalid_name, self.enum_symbols).end()
 
-
     def test_create_enum_with_dup_name(self):
         with self.assertRaisesRegexp(
                 schema.SchemaParseException,
                 self.duplicate_name_err.format(self.name)
         ):
             self.builder.begin_record(self.name)
-            self.builder.begin_field(
+            self.builder.add_field(
                 self.another_name,
                 self.builder.begin_enum(self.name, self.enum_symbols).end()
-            ).end_field()
+            )
             self.builder.end()
 
     def test_create_enum_with_invalid_symbols(self):
@@ -191,10 +190,10 @@ class TestAvroSchemaBuilder(unittest.TestCase):
                 self.duplicate_name_err.format(self.name)
         ):
             self.builder.begin_record(self.name)
-            self.builder.begin_field(
+            self.builder.add_field(
                 self.another_name,
                 self.builder.begin_fixed(self.name, self.fixed_size).end()
-            ).end_field()
+            )
             self.builder.end()
 
     def test_create_fixed_with_invalid_size(self):
@@ -280,14 +279,14 @@ class TestAvroSchemaBuilder(unittest.TestCase):
 
     def test_create_record(self):
         self.builder.begin_record(self.name)
-        self.builder.begin_field(
+        self.builder.add_field(
             'bar1',
             self.builder.create_int()
-        ).end_field()
-        self.builder.begin_field(
+        )
+        self.builder.add_field(
             'bar2',
             self.builder.begin_map(self.builder.create_double()).end()
-        ).end_field()
+        )
         actual_json = self.builder.end()
 
         expected_json = {
@@ -308,10 +307,10 @@ class TestAvroSchemaBuilder(unittest.TestCase):
             doc=self.doc,
             **self.metadata
         )
-        self.builder.begin_field(
+        self.builder.add_field(
             self.another_name,
             self.builder.create_int()
-        ).end_field()
+        )
         actual_json = self.builder.end()
 
         expected_json = {
@@ -328,7 +327,7 @@ class TestAvroSchemaBuilder(unittest.TestCase):
 
     def test_create_field_with_optional_attributes(self):
         self.builder.begin_record(self.name)
-        self.builder.begin_field(
+        self.builder.add_field(
             self.another_name,
             self.builder.create_boolean(),
             has_default=True,
@@ -337,7 +336,7 @@ class TestAvroSchemaBuilder(unittest.TestCase):
             aliases=self.aliases,
             doc=self.doc,
             **self.metadata
-        ).end_field()
+        )
         actual_json = self.builder.end()
 
         expected_field = {
@@ -367,10 +366,10 @@ class TestAvroSchemaBuilder(unittest.TestCase):
             self.builder.clear()
             with self.assertRaises(schema.SchemaParseException):
                 self.builder.begin_record(invalid_name)
-                self.builder.begin_field(
+                self.builder.add_field(
                     self.another_name,
                     self.builder.create_int()
-                ).end_field()
+                )
                 self.builder.end()
 
     def test_create_record_with_dup_name(self):
@@ -379,14 +378,14 @@ class TestAvroSchemaBuilder(unittest.TestCase):
                 self.duplicate_name_err.format(self.name)
         ):
             self.builder.begin_record(self.another_name)
-            self.builder.begin_field(
+            self.builder.add_field(
                 'bar1',
                 self.builder.begin_enum(self.name, self.enum_symbols).end()
-            ).end_field()
-            self.builder.begin_field(
+            )
+            self.builder.add_field(
                 'bar2',
                 self.builder.begin_record(self.name).end()
-            ).end_field()
+            )
             self.builder.end()
 
     def test_create_record_with_dup_field_name(self):
@@ -395,14 +394,14 @@ class TestAvroSchemaBuilder(unittest.TestCase):
                 "{0} already in use.".format(self.another_name)
         ):
             self.builder.begin_record(self.name)
-            self.builder.begin_field(
+            self.builder.add_field(
                 self.another_name,
                 self.builder.create_int()
-            ).end_field()
-            self.builder.begin_field(
+            )
+            self.builder.add_field(
                 self.another_name,
                 self.builder.create_string()
-            ).end_field()
+            )
             self.builder.end()
 
     def test_create_field_with_invalid_type(self):
@@ -410,20 +409,20 @@ class TestAvroSchemaBuilder(unittest.TestCase):
             self.builder.clear()
             with self.assertRaises(schema.SchemaParseException):
                 self.builder.begin_record(self.name)
-                self.builder.begin_field(
+                self.builder.add_field(
                     self.another_name,
                     invalid_schema
-                ).end_field()
+                )
                 self.builder.end()
 
     def test_create_field_with_invalid_sort_order(self):
         with self.assertRaises(schema.SchemaParseException):
             self.builder.begin_record(self.name)
-            self.builder.begin_field(
+            self.builder.add_field(
                 self.another_name,
                 self.builder.create_int(),
                 sort_order='asc'
-            ).end_field()
+            )
             self.builder.end()
 
     def test_create_union(self):
@@ -543,10 +542,10 @@ class TestAvroSchemaBuilder(unittest.TestCase):
             ]
         }
         self.builder.begin_with_schema_json(schema_json)
-        self.builder.begin_field(
+        self.builder.add_field(
             'field_new',
             self.builder.create_int()
-        ).end_field()
+        )
         actual_json = self.builder.end()
 
         expected_json = schema_json.copy()
@@ -556,8 +555,8 @@ class TestAvroSchemaBuilder(unittest.TestCase):
 
     def test_removed_field(self):
         self.builder.begin_record(self.name)
-        self.builder.begin_field('bar1', self.builder.create_int()).end_field()
-        self.builder.begin_field('bar2', self.builder.create_int()).end_field()
+        self.builder.add_field('bar1', self.builder.create_int())
+        self.builder.add_field('bar2', self.builder.create_int())
         self.builder.remove_field('bar1')
         actual_json = self.builder.end()
 


### PR DESCRIPTION
The avro_builder constructs json objects of Avro primitive and complex schema types (enum, fixed, map, array, record, and union). It performs schema validation in the end of schema building. The validation checks the schema correctness based on the rules currently implemented in the schema.py.
