### PR TITLE
changed setup.py to work for editable installation

### DIFF
--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -29,8 +29,8 @@ setup(
   name = 'avro',
   version = '@AVRO_VERSION@',
   packages = ['avro',],
-  package_dir = {'avro': 'src/avro'},
-  scripts = ["./scripts/avro"],
+  package_dir = {'': 'lang/py/src'},
+  scripts = ["lang/py/scripts/avro"],
 
   # Project uses simplejson, so ensure that it gets installed or upgraded
   # on the target machine


### PR DESCRIPTION
The current avro package installation in the schematizer requirements.txt is to install editable package. The existing setup.py only works for releases but not when the package is installed in the editable mode (i.e. using `-e`). Note that this is meant for the interim solution while we're waiting to see if the avro builder change is accepted by the upstream or if we need to create a separate package for it. Once it is decided, the change in the setup.py should be reverted back.

This change is tested by running `tox` in the schematizer service and the tests are passed clean.
