### PR TITLE
Changing package dir to use pip install via a commit sha

### DIFF
--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -29,8 +29,8 @@ setup(
   name = 'avro',
   version = '@AVRO_VERSION@',
   packages = ['avro',],
-  package_dir = {'avro': 'src/avro'},
-  scripts = ["./scripts/avro"],
+  package_dir = {'': 'lang/py/src'}
+  scripts = ["lang/py/scripts/avro"],
 
   #include_package_data=True,
   package_data={'avro': ['LICENSE', 'NOTICE']},


### PR DESCRIPTION
This change allows us to pin a certain commit sha in our requirements file to install a particular commit of avro.
I have tested this out by making the same changes in my [private](https://github.com/premsantosh/avro/commit/d6e07da58b466d6f89a11911f48cfb2fe700a400) repo:

```
pxu [~/pg/services/yelp_avro] (DATAPIPE-797 *) $ tox -r -edevenv
GLOB sdist-make: /nail/home/pxu/pg/services/yelp_avro/setup.py
devenv create: /nail/home/pxu/pg/services/yelp_avro/virtualenv_run
devenv installdeps: -rrequirements-dev.txt
devenv inst: /nail/home/pxu/pg/services/yelp_avro/.tox/dist/yelp_avro-0.1.4.zip
devenv runtests: PYTHONHASHSEED='1447502084'
__________________________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________________________
  devenv: commands succeeded
  congratulations :)
pxu [~/pg/services/yelp_avro] (DATAPIPE-797 *) $
```
