### PR TITLE
Point GitPush at trunk

### DIFF
--- a/scarab.yaml
+++ b/scarab.yaml
@@ -7,7 +7,8 @@ plugins:
         boto_auth_file: /etc/boto_cfg/scarab.cfg
     YelpTransport: {}
     # Event plugins
-    GitPush: {}
+    GitPush:
+        remote_target: trunk
     CleanDist: {}
     RecordPypiUpload: {}
     CleanupVenv: {}


### PR DESCRIPTION
Our fork uses trunk to denote the mainline, so releases should be pushed there.
