### PR TITLE
remove pytz dependency in python avro

### DIFF
--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -21,7 +21,7 @@ except ImportError:
   from distutils.core import setup
 from sys import version_info
 
-install_requires = ['pytz == 2016.4']
+install_requires = []
 if version_info[:2] <= (2, 5):
     install_requires.append('simplejson >= 2.0.9')
 

--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -39,7 +39,6 @@ uses the following mapping:
 import struct
 import sys
 import datetime
-import pytz
 from binascii import crc32
 from decimal import Decimal
 from decimal import getcontext
@@ -51,6 +50,7 @@ except ImportError:
 
 from avro import schema
 from avro import constants
+from avro.lib import timezones
 
 #
 # Constants
@@ -341,7 +341,7 @@ class BinaryDecoder(object):
     """
     timestamp_millis = self.read_long()
     timedelta = datetime.timedelta(microseconds=timestamp_millis * 1000)
-    unix_epoch_datetime = datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc) 
+    unix_epoch_datetime = datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=timezones.utc) 
     return unix_epoch_datetime + timedelta
 
   def read_timestamp_micros_from_long(self):
@@ -351,7 +351,7 @@ class BinaryDecoder(object):
     """
     timestamp_micros = self.read_long()
     timedelta = datetime.timedelta(microseconds=timestamp_micros)
-    unix_epoch_datetime = datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+    unix_epoch_datetime = datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=timezones.utc)
     return unix_epoch_datetime + timedelta
 
   def check_crc32(self, bytes):
@@ -586,8 +586,8 @@ class BinaryEncoder(object):
     Encode python datetime object as long.
     It stores the number of milliseconds from midnight of unix epoch, 1 January 1970.
     """
-    datum = datum.astimezone(tz=pytz.utc)
-    timedelta = datum - datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+    datum = datum.astimezone(tz=timezones.utc)
+    timedelta = datum - datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=timezones.utc)
     milliseconds = self._timedelta_total_microseconds(timedelta) / 1000
     self.write_long(long(milliseconds))
 
@@ -596,8 +596,8 @@ class BinaryEncoder(object):
     Encode python datetime object as long.
     It stores the number of microseconds from midnight of unix epoch, 1 January 1970.
     """
-    datum = datum.astimezone(tz=pytz.utc)
-    timedelta = datum - datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+    datum = datum.astimezone(tz=timezones.utc)
+    timedelta = datum - datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=timezones.utc)
     microseconds = self._timedelta_total_microseconds(timedelta)
     self.write_long(long(microseconds))
 

--- a/lang/py/src/avro/lib/timezones.py
+++ b/lang/py/src/avro/lib/timezones.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import tzinfo
+
+
+class UTCTzinfo(tzinfo):
+  def utcoffset(self, dt):
+    return timedelta(0)
+
+  def tzname(self, dt):
+    return "UTC"
+
+  def dst(self, dt):
+    return timedelta(0)
+
+utc = UTCTzinfo()
+
+
+# Test Time Zone with fixed offset and no DST
+class TSTTzinfo(tzinfo):
+  def utcoffset(self, dt):
+    return timedelta(hours=10)
+
+  def tzname(self, dt):
+    return "TST"
+
+  def dst(self, dt):
+    return timedelta(0)
+
+tst = TSTTzinfo()

--- a/lang/py/test/test_io.py
+++ b/lang/py/test/test_io.py
@@ -23,10 +23,10 @@ try:
 except ImportError:
   from StringIO import StringIO
 import set_avro_test_path
-import pytz
 
 from avro import schema
 from avro import io
+from avro.lib import timezones
 
 SCHEMAS_TO_VALIDATE = (
   ('"null"', None),
@@ -45,27 +45,27 @@ SCHEMAS_TO_VALIDATE = (
   ('{"type": "long", "logicalType": "time-micros"}', datetime.time(0, 0, 0, 000000)),
   (
     '{"type": "long", "logicalType": "timestamp-millis"}',
-    datetime.datetime(1000, 1, 1, 0, 0, 0, 000000, tzinfo=pytz.utc)
+    datetime.datetime(1000, 1, 1, 0, 0, 0, 000000, tzinfo=timezones.utc)
   ),
   (
     '{"type": "long", "logicalType": "timestamp-millis"}',
-    datetime.datetime(9999, 12, 31, 23, 59, 59, 999000, tzinfo=pytz.utc)
+    datetime.datetime(9999, 12, 31, 23, 59, 59, 999000, tzinfo=timezones.utc)
   ),
   (
     '{"type": "long", "logicalType": "timestamp-millis"}',
-    datetime.datetime(2000, 1, 18, 2, 2, 1, 100000, tzinfo=pytz.timezone('Europe/Moscow'))
+    datetime.datetime(2000, 1, 18, 2, 2, 1, 100000, tzinfo=timezones.tst)
   ),
   (
     '{"type": "long", "logicalType": "timestamp-micros"}',
-    datetime.datetime(1000, 1, 1, 0, 0, 0, 000000, tzinfo=pytz.utc)
+    datetime.datetime(1000, 1, 1, 0, 0, 0, 000000, tzinfo=timezones.utc)
   ),
   (
     '{"type": "long", "logicalType": "timestamp-micros"}',
-    datetime.datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=pytz.utc)
+    datetime.datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=timezones.utc)
   ),
   (
     '{"type": "long", "logicalType": "timestamp-micros"}',
-    datetime.datetime(2000, 1, 18, 2, 2, 1, 123499, tzinfo=pytz.timezone('Europe/Moscow'))
+    datetime.datetime(2000, 1, 18, 2, 2, 1, 123499, tzinfo=timezones.tst)
   ),
   ('{"type": "fixed", "logicalType": "decimal", "name": "Test", "size": 8, "precision": 5, "scale": 4}',
    Decimal('3.1415')),
@@ -241,7 +241,7 @@ class TestIO(unittest.TestCase):
         round_trip_datum = round_trip_datum.to_eng_string()
         datum = str(datum)
       if isinstance(round_trip_datum, datetime.datetime):
-        datum = datum.astimezone(tz=pytz.utc)
+        datum = datum.astimezone(tz=timezones.utc)
       if datum == round_trip_datum: correct += 1
     self.assertEquals(correct, len(SCHEMAS_TO_VALIDATE))
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -59,7 +59,3 @@ RUN gem install echoe yajl-ruby multi_json snappy
 
 # Install global Node modules
 RUN npm install -g grunt-cli
-
-# install dependancies for
-RUN apt-get update && apt-get install --no-install-recommends -y python-pip 
-RUN pip install pytz


### PR DESCRIPTION
This PR removes dependency from pytz because 
- as @jcnnghm pointed out its difficult to get our changes merged to upstream if our package introduces a new dependency. 
- Also having this dependency was causing version conflict in yelp-main build. 
- time logical type support doesn't actually use much of pytz function except UTC tzinfo class. 
