### PR TITLE
remove datum from the AvroTypeException error message

### DIFF
--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -94,8 +94,8 @@ class AvroTypeException(schema.AvroException):
   """Raised when datum is not an example of schema."""
   def __init__(self, expected_schema, datum, extra_msg=None):
     pretty_expected = json.dumps(json.loads(str(expected_schema)), indent=2)
-    fail_msg = "The datum %s is not an example of the schema %s"\
-               % (datum, pretty_expected)
+    # remove datum from the error message as it may contain sensitive data
+    fail_msg = "The datum is not an example of the schema %s" % (pretty_expected,)
     if extra_msg:
       fail_msg += '\n\nThe following fields failed to validate:\n' + extra_msg
     schema.AvroException.__init__(self, fail_msg)

--- a/lang/py/test/test_io.py
+++ b/lang/py/test/test_io.py
@@ -377,6 +377,13 @@ class TestIO(unittest.TestCase):
                   {"name": "E", "type": "int"}]}""")
     datum_to_write = {'E': 5, 'F': 'Bad'}
     self.assertRaises(io.AvroTypeException, write_datum, datum_to_write, writers_schema)
+    self.assertRaisesRegexp(
+      io.AvroTypeException,
+      "The datum is not an example of the schema",
+      write_datum,
+      datum_to_write,
+      writers_schema
+    )
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This change excludes datum from the `AvroTypeException` error message. This is to prevent showing sensitive data such as personal information when the exception is thrown.

@tiras-j, can you take a look when you get a chance? Thanks! :)